### PR TITLE
Clean up

### DIFF
--- a/LoreMaster/Enums/Area.cs
+++ b/LoreMaster/Enums/Area.cs
@@ -11,11 +11,14 @@ public enum Area
     None,
 
     /// <summary>
+    /// This in unused, it only exists to compare against the last zone. Sorry peaks, really liked your music :c
+    /// </summary>
+    Peaks,
+
+    /// <summary>
     /// Dirtmouth zones: Dirtmouth and King's Pass
     /// </summary>
     Dirtmouth,
-
-    Cliffs,
 
     /// <summary>
     /// Crossroad zones: Crossroads, Ancient Mound, Black Egg Temple.
@@ -24,25 +27,25 @@ public enum Area
 
     Greenpath,
 
-    FungalWastes,
+    Cliffs,
 
-    FogCanyon,
+    FungalWastes,
 
     CityOfTears,
 
-    WaterWays,
-
-    Deepnest,
-
-    AncientBasin,
-
-    KingdomsEdge,
-
-    Peaks,
+    Waterways,
 
     RestingGrounds,
 
+    FogCanyon,
+
+    AncientBasin,
+
+    Deepnest,
+
     QueensGarden,
+
+    KingdomsEdge,
 
     WhitePalace
 }

--- a/LoreMaster/LorePowers/Ancient Basin/WeDontTalkAboutShadePower.cs
+++ b/LoreMaster/LorePowers/Ancient Basin/WeDontTalkAboutShadePower.cs
@@ -1,12 +1,9 @@
-using ItemChanger.Extensions;
-using ItemChanger.FsmStateActions;
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
 using LoreMaster.Enums;
-using LoreMaster.Extensions;
 using Modding;
 using System;
 using UnityEngine;
-using HutongGames.PlayMaker;
-using HutongGames.PlayMaker.Actions;
 
 namespace LoreMaster.LorePowers.Ancient_Basin;
 
@@ -41,40 +38,28 @@ public class WeDontTalkAboutShadePower : Power
 
     private void OnSetPlayerDataIntAction(On.HutongGames.PlayMaker.Actions.SetPlayerDataInt.orig_OnEnter orig, SetPlayerDataInt self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Hero Death") && string.Equals(self.Fsm.FsmComponent.FsmName, "Hero Death Anim") && string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Remove Geo") && string.Equals(self.intName.Value, "geoPool") && Active)
-        {
+        if (string.Equals(self.Fsm.GameObjectName, "Hero Death") && string.Equals(self.Fsm.Name, "Hero Death Anim") 
+            && string.Equals(self.State.Name, "Remove Geo") && string.Equals(self.intName.Value, "geoPool"))
             self.value.Value += PlayerData.instance.GetInt(nameof(PlayerData.instance.geoPool)) > 1 ? PlayerData.instance.GetInt(nameof(PlayerData.instance.geoPool)) / 2 : 0;
-        }
-
         orig(self);
     }
 
     private void OnPlayerDataBoolTestAction(On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.orig_OnEnter orig, PlayerDataBoolTest self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.FsmName, "Deactivate if !SoulLimited") && Active)
-        {
+        if (string.Equals(self.Fsm.Name, "Deactivate if !SoulLimited"))
             self.isFalse = string.Equals(PlayerData.instance.GetString(nameof(PlayerData.instance.shadeScene)), "None") ? FsmEvent.GetFsmEvent("DEACTIVATE") : null;
-        }
-
         orig(self);
     }
 
     #endregion
 
-    #region Protected Methods
-
-    /// <inheritdoc/>
-    protected override void Initialize()
-    {
-
-        On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter += OnPlayerDataBoolTestAction;
-        On.HutongGames.PlayMaker.Actions.SetPlayerDataInt.OnEnter += OnSetPlayerDataIntAction;
-
-    }
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()
     {
+        On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter += OnPlayerDataBoolTestAction;
+        On.HutongGames.PlayMaker.Actions.SetPlayerDataInt.OnEnter += OnSetPlayerDataIntAction;
         ModHooks.AfterPlayerDeadHook += AfterPlayerDied;
         PlayerData.instance.SetBool("soulLimited", false);
     }
@@ -82,7 +67,10 @@ public class WeDontTalkAboutShadePower : Power
     /// <inheritdoc/>
     protected override void Disable()
     {
+        On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter -= OnPlayerDataBoolTestAction;
+        On.HutongGames.PlayMaker.Actions.SetPlayerDataInt.OnEnter -= OnSetPlayerDataIntAction;
         ModHooks.AfterPlayerDeadHook -= AfterPlayerDied;
+        // Reapply the soul limiter if it should be active right now (when the shade is active)
         if (!PlayerData.instance.GetString(nameof(PlayerData.instance.shadeScene)).Equals("None"))
             PlayerData.instance.StartSoulLimiter();
     }

--- a/LoreMaster/LorePowers/CityOfTears/DeliciousMealPower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/DeliciousMealPower.cs
@@ -46,7 +46,7 @@ public class DeliciousMealPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/CityOfTears/HappyFatePower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/HappyFatePower.cs
@@ -86,7 +86,7 @@ public class HappyFatePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/CityOfTears/HotStreakPower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/HotStreakPower.cs
@@ -50,7 +50,7 @@ public class HotStreakPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/CityOfTears/MarissasAudiencePower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/MarissasAudiencePower.cs
@@ -54,7 +54,7 @@ public class MarissasAudiencePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/CityOfTears/OverwhelmingPowerPower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/OverwhelmingPowerPower.cs
@@ -93,7 +93,7 @@ public class OverwhelmingPowerPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/CityOfTears/PureSpiritPower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/PureSpiritPower.cs
@@ -37,7 +37,7 @@ internal class PureSpiritPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     protected override void Initialize()
     {

--- a/LoreMaster/LorePowers/CityOfTears/SoulExtractEfficiencyPower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/SoulExtractEfficiencyPower.cs
@@ -1,7 +1,4 @@
-using ItemChanger.Extensions;
-using ItemChanger.FsmStateActions;
 using LoreMaster.Enums;
-using LoreMaster.Extensions;
 using Modding;
 
 namespace LoreMaster.LorePowers.CityOfTears;
@@ -23,8 +20,7 @@ public class SoulExtractEfficiencyPower : Power
 
     private void OnSetBoolValueAction(On.HutongGames.PlayMaker.Actions.SetBoolValue.orig_OnEnter orig, HutongGames.PlayMaker.Actions.SetBoolValue self)
     {
-
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Knight") && string.Equals(self.Fsm.FsmComponent.FsmName, "Spell Control") && string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Inactive") && Active)
+        if (string.Equals(self.Fsm.GameObjectName, "Knight") && string.Equals(self.Fsm.Name, "Spell Control") && string.Equals(self.State.Name, "Inactive"))
         {
             int currentMP = PlayerData.instance.GetInt(nameof(PlayerData.instance.MPCharge));
             int maxMP = PlayerData.instance.GetInt(nameof(PlayerData.instance.maxMP));
@@ -34,31 +30,31 @@ public class SoulExtractEfficiencyPower : Power
             {
                 int neededMP = maxMP - currentMP;
                 if (reserveMP - neededMP >= 0)
-                {
                     reserveMP -= neededMP;
-                }
             }
             HeroController.instance.TakeReserveMP(reserveMP);
             HeroController.instance.AddMPCharge(reserveMP);
         }
-
         orig(self);
     }
 
     #endregion
 
-        #region Protected Methods
+    #region Control
 
-    protected override void Initialize()
-    {
+    /// <inheritdoc/>
+    protected override void Enable() 
+    { 
+        ModHooks.SoulGainHook += OnSoulGain;
         On.HutongGames.PlayMaker.Actions.SetBoolValue.OnEnter += OnSetBoolValueAction;
     }
 
     /// <inheritdoc/>
-    protected override void Enable() => ModHooks.SoulGainHook += OnSoulGain;
-    
-    /// <inheritdoc/>
-    protected override void Disable() => ModHooks.SoulGainHook -= OnSoulGain;
+    protected override void Disable()
+    {
+        ModHooks.SoulGainHook -= OnSoulGain;
+        On.HutongGames.PlayMaker.Actions.SetBoolValue.OnEnter -= OnSetBoolValueAction;
+    }
 
     #endregion
 }

--- a/LoreMaster/LorePowers/CityOfTears/TouristPower.cs
+++ b/LoreMaster/LorePowers/CityOfTears/TouristPower.cs
@@ -20,7 +20,7 @@ public class TouristPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => Inspected = true;

--- a/LoreMaster/LorePowers/Crossroads/DiamondDashPower.cs
+++ b/LoreMaster/LorePowers/Crossroads/DiamondDashPower.cs
@@ -67,7 +67,7 @@ public class DiamondDashPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Crossroads/GreaterMindPower.cs
+++ b/LoreMaster/LorePowers/Crossroads/GreaterMindPower.cs
@@ -32,7 +32,7 @@ public class GreaterMindPower : Power
         {Area.QueensGarden, "Queen's Gardens"},
         {Area.Peaks, "Crystal Peaks"},
         {Area.RestingGrounds, "Resting Grounds"},
-        {Area.WaterWays, "Waterways"},
+        {Area.Waterways, "Waterways"},
         {Area.KingdomsEdge, "Kingdom's Edge"},
         {Area.FogCanyon, "Fog Canyon"},
         {Area.Cliffs, "Howling Cliffs"},
@@ -64,7 +64,7 @@ public class GreaterMindPower : Power
         { }
     };
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Crossroads/ReluctantPilgrimPower.cs
+++ b/LoreMaster/LorePowers/Crossroads/ReluctantPilgrimPower.cs
@@ -123,7 +123,7 @@ public class ReluctantPilgrimPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Deepnest/InfestedPower.cs
+++ b/LoreMaster/LorePowers/Deepnest/InfestedPower.cs
@@ -32,7 +32,7 @@ public class InfestedPower : Power
 
     #endregion
 
-    #region Event Handler
+    #region Event handler
 
     private void HealthManager_TakeDamage(On.HealthManager.orig_TakeDamage orig, HealthManager self, HitInstance hitInstance)
     {
@@ -65,39 +65,36 @@ public class InfestedPower : Power
         orig(self, attackDirection, attackType, ignoreEvasion);
     }
 
-    private void PlayMakerFSM_OnEnable(On.PlayMakerFSM.orig_OnEnable orig, PlayMakerFSM self)
+    private void OnIntCompareAction(On.HutongGames.PlayMaker.Actions.IntCompare.orig_OnEnter orig, IntCompare self)
     {
-        if (string.Equals(self.FsmName,"Attack") && string.Equals(self.transform.parent?.name, "Weaverling(Clone)"))
-        {
-            self.GetState("Hit").ReplaceAction(new Lambda(() =>
-            {
-                if (Active)
-                    Infest(self.FsmVariables.FindFsmGameObject("Enemy").Value);
-                self.FsmVariables.FindFsmInt("Enemy HP").Value -= self.FsmVariables.FindFsmInt("Damage").Value;
-            })
-            { Name = "Infest" }, 4);
-        }
+        if (string.Equals(self.Fsm.Name, "Attack") && string.Equals(self.Fsm.FsmComponent.gameObject.transform.parent?.gameObject.name, "Weaverling(Clone)") 
+            && string.Equals(self.State.Name, "Hit"))
+            Infest(self.Fsm.Variables.FindFsmGameObject("Enemy").Value);
         orig(self);
     }
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
+    /// <inheritdoc/>
+    protected override void Initialize()
+     => _weaverPrefab = GameObject.Find("Knight/Charm Effects").LocateMyFSM("Weaverling Control").GetState("Spawn").GetFirstActionOfType<SpawnObjectFromGlobalPool>().gameObject.Value;
+    
     /// <inheritdoc/>
     protected override void Enable()
     {
+        On.HutongGames.PlayMaker.Actions.IntCompare.OnEnter += OnIntCompareAction;
         On.HealthManager.TakeDamage += HealthManager_TakeDamage;
         On.HealthManager.Die += HealthManager_Die;
-        On.PlayMakerFSM.OnEnable += PlayMakerFSM_OnEnable;
     }
 
     /// <inheritdoc/>
     protected override void Disable()
     {
+        On.HutongGames.PlayMaker.Actions.IntCompare.OnEnter -= OnIntCompareAction;
         On.HealthManager.TakeDamage -= HealthManager_TakeDamage;
         On.HealthManager.Die -= HealthManager_Die;
-        On.PlayMakerFSM.OnEnable -= PlayMakerFSM_OnEnable;
     }
 
     #endregion

--- a/LoreMaster/LorePowers/Deepnest/MaskOverchargePower.cs
+++ b/LoreMaster/LorePowers/Deepnest/MaskOverchargePower.cs
@@ -53,7 +53,7 @@ public class MaskOverchargePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Dirtmouth/CaringShellPower.cs
+++ b/LoreMaster/LorePowers/Dirtmouth/CaringShellPower.cs
@@ -34,7 +34,7 @@ public class CaringShellPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Dirtmouth/ElderbugHitListPower.cs
+++ b/LoreMaster/LorePowers/Dirtmouth/ElderbugHitListPower.cs
@@ -79,7 +79,7 @@ public class ElderbugHitListPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Dirtmouth/ScrewTheRulesPower.cs
+++ b/LoreMaster/LorePowers/Dirtmouth/ScrewTheRulesPower.cs
@@ -1,9 +1,5 @@
-using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
-using ItemChanger.Extensions;
-using ItemChanger.FsmStateActions;
 using LoreMaster.Enums;
-using LoreMaster.Extensions;
 using MonoMod.Cil;
 using System;
 using UnityEngine;
@@ -25,38 +21,28 @@ public class ScrewTheRulesPower : Power
 
     private void OnSetFsmFloatAction(On.HutongGames.PlayMaker.Actions.SetFsmFloat.orig_OnEnter orig, SetFsmFloat self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Charm Effects") && string.Equals(self.Fsm.FsmComponent.FsmName, "Fury") && string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Activate"))
-        {
+        if (string.Equals(self.Fsm.GameObjectName, "Charm Effects") && string.Equals(self.Fsm.Name, "Fury") && string.Equals(self.State.Name, "Activate"))
             self.setValue.Value = Active ? 1.5f : 1.75f;
-        }
         orig(self);
     }
 
     private void OnFloatMultiplyAction(On.HutongGames.PlayMaker.Actions.FloatMultiply.orig_OnEnter orig, FloatMultiply self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.FsmName, "nailart_damage") && string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Fury?"))
-        {
+        if (string.Equals(self.Fsm.Name, "nailart_damage") && string.Equals(self.State.Name, "Fury?"))
             self.multiplyBy.Value = Active ? 1.5f : 1.75f;
-        }
-        else if (self.Fsm.FsmComponent.gameObject.name.Contains("Grubberfly Beam") && string.Equals(self.Fsm.FsmComponent.FsmName, "Control"))
-        {
+        else if (self.Fsm.GameObjectName.Contains("Grubberfly Beam") && string.Equals(self.Fsm.Name, "Control"))
             self.multiplyBy.Value = Active ? 1.3f : 1.5f;
-        }
         orig(self);
     }
 
     private void OnIntCompareAction(On.HutongGames.PlayMaker.Actions.IntCompare.orig_OnEnter orig, IntCompare self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Charm Effects") && string.Equals(self.Fsm.FsmComponent.FsmName, "Fury") && (string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Check HP") || string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Recheck")) && PlayerData.instance.GetInt(nameof(PlayerData.instance.health)) == 2 && Active)
+        if (string.Equals(self.Fsm.GameObjectName, "Charm Effects") && string.Equals(self.Fsm.Name, "Fury") && (string.Equals(self.State.Name, "Check HP") || string.Equals(self.State.Name, "Recheck")) && PlayerData.instance.GetInt(nameof(PlayerData.instance.health)) == 2)
         {
-            if (self.Fsm.FsmComponent.ActiveStateName == "Check HP")
-            {
+            if (string.Equals(self.State.Name, "Check HP"))
                 self.Fsm.FsmComponent.SendEvent("FURY");
-            }
-            else if (self.Fsm.FsmComponent.ActiveStateName == "Recheck")
-            {
+            else if (string.Equals(self.State.Name, "Recheck"))
                 self.Fsm.FsmComponent.SendEvent("RETURN");
-            }
         }
         orig(self);
     }
@@ -64,7 +50,6 @@ public class ScrewTheRulesPower : Power
     private void HeroController_Attack(ILContext il)
     {
         ILCursor cursor = new(il);
-
         try
         {
             // Modifies right/left slash, up slash and down slash (the first health check is for full health, which we ignore here)
@@ -83,7 +68,7 @@ public class ScrewTheRulesPower : Power
                 cursor.EmitDelegate<Func<int, int>>((x) => x <= 2 ? 1 : x);
             }
         }
-        catch (System.Exception exception)
+        catch (Exception exception)
         {
             LoreMaster.Instance.LogError("Couldn't modify grubberfly fury condition: " + exception);
         }
@@ -91,13 +76,12 @@ public class ScrewTheRulesPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()
     {
         On.HutongGames.PlayMaker.Actions.FloatMultiply.OnEnter += OnFloatMultiplyAction;
-        On.HutongGames.PlayMaker.Actions.IntCompare.OnEnter += OnIntCompareAction;
         On.HutongGames.PlayMaker.Actions.SetFsmFloat.OnEnter += OnSetFsmFloatAction;
     }
 
@@ -105,18 +89,27 @@ public class ScrewTheRulesPower : Power
     protected override void Enable()
     {
         IL.HeroController.Attack += HeroController_Attack;
+        On.HutongGames.PlayMaker.Actions.IntCompare.OnEnter += OnIntCompareAction;
     }
 
     /// <inheritdoc/>
     protected override void Disable()
     {
         IL.HeroController.Attack -= HeroController_Attack;
+        On.HutongGames.PlayMaker.Actions.IntCompare.OnEnter -= OnIntCompareAction;
         // Disable the fury effect if you leave with 2 hp.
         if (PlayerData.instance.GetInt(nameof(PlayerData.instance.health)) == 2)
         {
             PlayMakerFSM fsm = GameObject.Find("Knight/Charm Effects").LocateMyFSM("Fury");
             fsm.SendEvent("HERO HEALED");
         }
+    }
+
+    /// <inheritdoc/>
+    protected override void Terminate()
+    {
+        On.HutongGames.PlayMaker.Actions.FloatMultiply.OnEnter -= OnFloatMultiplyAction;
+        On.HutongGames.PlayMaker.Actions.SetFsmFloat.OnEnter -= OnSetFsmFloatAction;
     }
 
     #endregion

--- a/LoreMaster/LorePowers/Dirtmouth/TrueFormPower.cs
+++ b/LoreMaster/LorePowers/Dirtmouth/TrueFormPower.cs
@@ -100,7 +100,7 @@ public class TrueFormPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Dirtmouth/WellFocusedPower.cs
+++ b/LoreMaster/LorePowers/Dirtmouth/WellFocusedPower.cs
@@ -21,7 +21,7 @@ public class WellFocusedPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/FogCanyon/FriendOfTheJellyfishPower.cs
+++ b/LoreMaster/LorePowers/FogCanyon/FriendOfTheJellyfishPower.cs
@@ -56,7 +56,7 @@ public class FriendOfTheJellyfishPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/FogCanyon/JellyBellyPower.cs
+++ b/LoreMaster/LorePowers/FogCanyon/JellyBellyPower.cs
@@ -38,7 +38,7 @@ public class JellyBellyPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/FogCanyon/JellyfishFlowPower.cs
+++ b/LoreMaster/LorePowers/FogCanyon/JellyfishFlowPower.cs
@@ -1,8 +1,4 @@
-using ItemChanger.Extensions;
-using ItemChanger.FsmStateActions;
 using LoreMaster.Enums;
-using LoreMaster.Extensions;
-using UnityEngine;
 
 namespace LoreMaster.LorePowers.FogCanyon;
 
@@ -21,30 +17,25 @@ public class JellyfishFlowPower : Power
 
     private void OnSetVelocity2DAction(On.HutongGames.PlayMaker.Actions.SetVelocity2d.orig_OnEnter orig, HutongGames.PlayMaker.Actions.SetVelocity2d self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Knight") && string.Equals(self.Fsm.FsmComponent.FsmName, "Surface Water"))
-        {
-            if (string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Swim Right"))
-            {
+        if (string.Equals(self.Fsm.GameObjectName, "Knight") && string.Equals(self.Fsm.Name, "Surface Water"))
+            if (string.Equals(self.State.Name, "Swim Right"))
                 self.x.Value = Active ? 20f : 5f;
-            }
-            else if (string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Swim Left"))
-            {
+            else if (string.Equals(self.State.Name, "Swim Left"))
                 self.x.Value = Active ? -20f : -5f;
-            }
-        }
-
         orig(self);
     }
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()
-    {
-        On.HutongGames.PlayMaker.Actions.SetVelocity2d.OnEnter += OnSetVelocity2DAction;
-    }
+    => On.HutongGames.PlayMaker.Actions.SetVelocity2d.OnEnter += OnSetVelocity2DAction;
+
+    /// <inheritdoc/>
+    protected override void Terminate()
+    => On.HutongGames.PlayMaker.Actions.SetVelocity2d.OnEnter -= OnSetVelocity2DAction;
 
     #endregion
 }

--- a/LoreMaster/LorePowers/FungalWastes/BagOfMushroomsPower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/BagOfMushroomsPower.cs
@@ -205,7 +205,7 @@ public class BagOfMushroomsPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/FungalWastes/EternalValorPower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/EternalValorPower.cs
@@ -43,7 +43,7 @@ public class EternalValorPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => ModHooks.SlashHitHook += ModHooks_SlashHitHook;

--- a/LoreMaster/LorePowers/FungalWastes/GloryOfTheWealthPower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/GloryOfTheWealthPower.cs
@@ -104,7 +104,7 @@ public class GloryOfTheWealthPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/FungalWastes/ImposterPower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/ImposterPower.cs
@@ -28,7 +28,7 @@ public class ImposterPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => On.HeroController.AddHealth += ExtraHeal;

--- a/LoreMaster/LorePowers/FungalWastes/MantisStylePower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/MantisStylePower.cs
@@ -32,7 +32,7 @@ public class MantisStylePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/FungalWastes/OneOfUsPower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/OneOfUsPower.cs
@@ -12,7 +12,7 @@ public class OneOfUsPower : Power
 {
     #region Members
 
-    private GameObject _cloud;
+    private GameObject _cloud = GameObject.Find("_GameManager").transform.Find("GlobalPool/Knight Spore Cloud(Clone)").gameObject;
 
     #endregion
 
@@ -24,21 +24,17 @@ public class OneOfUsPower : Power
 
     #region Properties
 
+    /// <summary>
+    /// Gets the cloud object
+    /// </summary>
     public GameObject Cloud => _cloud == null ? GameObject.Find("_GameManager").transform.Find("GlobalPool/Knight Spore Cloud(Clone)").gameObject : _cloud;
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => _runningCoroutine = LoreMaster.Instance.Handler.StartCoroutine(EmitCloud());
-
-    /// <inheritdoc/>
-    protected override void Disable()
-    {
-        if (_runningCoroutine != null)
-            LoreMaster.Instance.Handler.StopCoroutine(_runningCoroutine);
-    }
 
     #endregion
 
@@ -56,8 +52,8 @@ public class OneOfUsPower : Power
             {
                 GameObject newCloud = GameObject.Instantiate(Cloud, HeroController.instance.transform.position,
                 Quaternion.identity);
-                newCloud.LocateMyFSM("Control").ChangeTransition("Init", "NORMAL", Active ? "Deep" : "Normal");
                 newCloud.SetActive(true);
+                newCloud.LocateMyFSM("Control").ChangeTransition("Init", "NORMAL", "Deep");
                 yield return new WaitForSeconds(4.1f);
                 GameObject.Destroy(newCloud);
             }

--- a/LoreMaster/LorePowers/FungalWastes/UnitedWeStandPower.cs
+++ b/LoreMaster/LorePowers/FungalWastes/UnitedWeStandPower.cs
@@ -44,7 +44,7 @@ public class UnitedWeStandPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Greenpath/CamouflagePower.cs
+++ b/LoreMaster/LorePowers/Greenpath/CamouflagePower.cs
@@ -19,7 +19,7 @@ public class CamouflagePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Greenpath/GiftOfUnnPower.cs
+++ b/LoreMaster/LorePowers/Greenpath/GiftOfUnnPower.cs
@@ -1,8 +1,5 @@
-using ItemChanger.FsmStateActions;
-using LoreMaster.Enums;
-using LoreMaster.Extensions;
-using LoreMaster.Helper;
 using HutongGames.PlayMaker;
+using LoreMaster.Enums;
 
 namespace LoreMaster.LorePowers.Greenpath;
 
@@ -18,40 +15,37 @@ public class GiftOfUnnPower : Power
 
     private void OnPlayerDataBoolTestAction(On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.orig_OnEnter orig, HutongGames.PlayMaker.Actions.PlayerDataBoolTest self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Knight") && string.Equals(self.Fsm.FsmComponent.FsmName, "Spell Control"))
-        {
-            if (string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Start Slug Anim"))
-            {
+        if (string.Equals(self.Fsm.GameObjectName, "Knight") && string.Equals(self.Fsm.Name, "Spell Control"))
+            if (string.Equals(self.State.Name, "Start Slug Anim"))
                 self.isFalse = Active ? null : FsmEvent.GetFsmEvent("FINISHED");
-            }
-            else if (string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Slug?"))
-            {
+            else if (string.Equals(self.State.Name, "Slug?"))
                 self.isFalse = Active ? FsmEvent.GetFsmEvent("SLUG") : null;
-            }
-        }
         orig(self);
     }
 
-    // If the player has shape of unn equipped, it gives 15 mp on a successful cast (this is added, to prevent making the charm useless)
     private void OnSpawnObjectFromGlobalPoolAction(On.HutongGames.PlayMaker.Actions.SpawnObjectFromGlobalPool.orig_OnEnter orig, HutongGames.PlayMaker.Actions.SpawnObjectFromGlobalPool self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Knight") && string.Equals(self.Fsm.FsmComponent.FsmName, "Spell Control") && string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Focus Heal 2") && PlayerData.instance.GetBool(nameof(PlayerData.instance.equippedCharm_28)) && Active)
-        {
+        if (Active && string.Equals(self.Fsm.GameObjectName, "Knight") && string.Equals(self.Fsm.Name, "Spell Control")
+            && string.Equals(self.State.Name, "Focus Heal 2") && PlayerData.instance.GetBool(nameof(PlayerData.instance.equippedCharm_28)))
             HeroController.instance.AddMPCharge(15);
-        }
-
         orig(self);
     }
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()
     {
         On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter += OnPlayerDataBoolTestAction;
         On.HutongGames.PlayMaker.Actions.SpawnObjectFromGlobalPool.OnEnter += OnSpawnObjectFromGlobalPoolAction;
+    }
+
+    protected override void Terminate()
+    {
+        On.HutongGames.PlayMaker.Actions.PlayerDataBoolTest.OnEnter -= OnPlayerDataBoolTestAction;
+        On.HutongGames.PlayMaker.Actions.SpawnObjectFromGlobalPool.OnEnter -= OnSpawnObjectFromGlobalPoolAction;
     }
 
     #endregion

--- a/LoreMaster/LorePowers/Greenpath/GraspOfLifePower.cs
+++ b/LoreMaster/LorePowers/Greenpath/GraspOfLifePower.cs
@@ -118,7 +118,7 @@ public class GraspOfLifePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Greenpath/MindblastOfUnnPower.cs
+++ b/LoreMaster/LorePowers/Greenpath/MindblastOfUnnPower.cs
@@ -83,7 +83,7 @@ public class MindblastOfUnnPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Greenpath/ReturnToUnnPower.cs
+++ b/LoreMaster/LorePowers/Greenpath/ReturnToUnnPower.cs
@@ -21,7 +21,7 @@ public class ReturnToUnnPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Greenpath/TouchGrassPower.cs
+++ b/LoreMaster/LorePowers/Greenpath/TouchGrassPower.cs
@@ -70,7 +70,7 @@ public class TouchGrassPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/HowlingCliffs/LifebloodOmenPower.cs
+++ b/LoreMaster/LorePowers/HowlingCliffs/LifebloodOmenPower.cs
@@ -23,7 +23,7 @@ public class LifebloodOmenPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/HowlingCliffs/StagAdoptionPower.cs
+++ b/LoreMaster/LorePowers/HowlingCliffs/StagAdoptionPower.cs
@@ -1,16 +1,10 @@
 using HutongGames.PlayMaker;
-using HutongGames.PlayMaker.Actions;
 using ItemChanger.Extensions;
 using ItemChanger.FsmStateActions;
 using LoreMaster.Enums;
 using LoreMaster.Helper;
 using Modding;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace LoreMaster.LorePowers.HowlingCliffs;

--- a/LoreMaster/LorePowers/KingdomsEdge/WisdomOfTheSagePower.cs
+++ b/LoreMaster/LorePowers/KingdomsEdge/WisdomOfTheSagePower.cs
@@ -28,21 +28,18 @@ public class WisdomOfTheSagePower : Power
     private void OnSetFsmIntAction(On.HutongGames.PlayMaker.Actions.SetFsmInt.orig_DoSetFsmInt orig, HutongGames.PlayMaker.Actions.SetFsmInt self)
     {
         orig(self);
-        if (string.Equals(self.Fsm.FsmComponent.gameObject.name, "Charm Effects") && string.Equals(self.Fsm.FsmComponent.FsmName, "Set Spell Cost"))
-        {
+        if (string.Equals(self.Fsm.GameObjectName, "Charm Effects") && string.Equals(self.Fsm.Name, "Set Spell Cost"))
             GameObject.Find("Knight").LocateMyFSM("Spell Control").FsmVariables.FindFsmInt("MP Cost").Value -= _soulBonus;
-        }
     }
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()
-    {
-        On.HutongGames.PlayMaker.Actions.SetFsmInt.DoSetFsmInt += OnSetFsmIntAction;
-    }
+    => On.HutongGames.PlayMaker.Actions.SetFsmInt.DoSetFsmInt += OnSetFsmIntAction;
+    
 
     /// <inheritdoc/>
     protected override void Enable()
@@ -59,6 +56,10 @@ public class WisdomOfTheSagePower : Power
             GameObject.Find("Knight").LocateMyFSM("Spell Control").FsmVariables.FindFsmInt("MP Cost").Value += _soulBonus;
         _soulBonus = 0;
     }
+
+    /// <inheritdoc/>
+    protected override void Terminate()
+    => On.HutongGames.PlayMaker.Actions.SetFsmInt.DoSetFsmInt -= OnSetFsmIntAction;
 
     #endregion
 

--- a/LoreMaster/LorePowers/KingdomsEdge/YouLikeJazzPower.cs
+++ b/LoreMaster/LorePowers/KingdomsEdge/YouLikeJazzPower.cs
@@ -29,7 +29,7 @@ internal class YouLikeJazzPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Peaks/DiamondCorePower.cs
+++ b/LoreMaster/LorePowers/Peaks/DiamondCorePower.cs
@@ -72,7 +72,7 @@ public class DiamondCorePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/Power.cs
+++ b/LoreMaster/LorePowers/Power.cs
@@ -101,6 +101,11 @@ public abstract class Power
     protected virtual void Disable() { }
 
     /// <summary>
+    /// Called when powers disable themself entirely (so that <see cref="Initialize"/> will be called upon next activation).
+    /// </summary>
+    protected virtual void Terminate() { }
+
+    /// <summary>
     /// Enables the twisted version of this power.
     /// </summary>
     protected virtual void TwistEnable() { }
@@ -165,6 +170,8 @@ public abstract class Power
     /// <param name="backToMenu">This is used to tell <see cref="EnablePower"/> to do the initialize again, if you reload the game.</param>
     internal void DisablePower(bool backToMenu = false)
     {
+        if (backToMenu)
+            Terminate();
         _initialized = !backToMenu;
         if (!Active)
             return;
@@ -183,8 +190,6 @@ public abstract class Power
             LoreMaster.Instance.LogError("Error while loading " + PowerName + ": " + exception.StackTrace);
         }
     } 
-
-    #endregion
 
     #endregion
 }

--- a/LoreMaster/LorePowers/QueensGarden/FlowerRingPower.cs
+++ b/LoreMaster/LorePowers/QueensGarden/FlowerRingPower.cs
@@ -1,9 +1,5 @@
-using ItemChanger.Extensions;
-using ItemChanger.FsmStateActions;
-using LoreMaster.Enums;
-using LoreMaster.Extensions;
-using System;
 using HutongGames.PlayMaker.Actions;
+using LoreMaster.Enums;
 
 namespace LoreMaster.LorePowers.QueensGarden;
 
@@ -19,10 +15,9 @@ public class FlowerRingPower : Power
 
     private void OnConvertFloatToIntAction(On.HutongGames.PlayMaker.Actions.ConvertFloatToInt.orig_OnEnter orig, ConvertFloatToInt self)
     {
-        if (string.Equals(self.Fsm.FsmComponent.FsmName, "nailart_damage") && string.Equals(self.Fsm.FsmComponent.ActiveStateName, "Set"))
+        if (string.Equals(self.Fsm.Name, "nailart_damage") && string.Equals(self.State.Name, "Set"))
         {
             float damageMultiplier = 1f;
-
             if (PlayerData.instance.GetBool(nameof(PlayerData.instance.elderbugGaveFlower)))
                 damageMultiplier += .1f;
             if (PlayerData.instance.GetBool(nameof(PlayerData.instance.givenEmilitiaFlower)))
@@ -44,15 +39,15 @@ public class FlowerRingPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
-    /// <inheritdoc/>
+    protected override void Enable()
+    => On.HutongGames.PlayMaker.Actions.ConvertFloatToInt.OnEnter += OnConvertFloatToIntAction;
 
-    protected override void Initialize()
-    {
-        On.HutongGames.PlayMaker.Actions.ConvertFloatToInt.OnEnter += OnConvertFloatToIntAction;
-    }
+    /// <inheritdoc/>
+    protected override void Disable()
+    => On.HutongGames.PlayMaker.Actions.ConvertFloatToInt.OnEnter -= OnConvertFloatToIntAction;
 
     #endregion
 }

--- a/LoreMaster/LorePowers/QueensGarden/FollowTheLightPower.cs
+++ b/LoreMaster/LorePowers/QueensGarden/FollowTheLightPower.cs
@@ -23,7 +23,7 @@ public class FollowTheLightPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/QueensGarden/QueenThornsPower.cs
+++ b/LoreMaster/LorePowers/QueensGarden/QueenThornsPower.cs
@@ -27,9 +27,15 @@ public class QueenThornsPower : Power
 
     #region Properties
 
+    /// <summary>
+    /// Gets the value which indicates if the player can heal (current health smaller than max health)
+    /// </summary>
     public bool CanHeal => PlayerData.instance.GetBool("equippedCharm_27")
         || (PlayerData.instance.GetInt("Health") < PlayerData.instance.GetInt("maxHealth"));
 
+    /// <summary>
+    /// Gets the thorn object-
+    /// </summary>
     public GameObject Thorns => _thorns == null ? _thorns = HeroController.instance.transform.Find("Charm Effects/Thorn Hit").gameObject : _thorns;
 
     #endregion
@@ -132,7 +138,7 @@ public class QueenThornsPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/RestingGrounds/DreamBlessingPower.cs
+++ b/LoreMaster/LorePowers/RestingGrounds/DreamBlessingPower.cs
@@ -84,7 +84,7 @@ public class DreamBlessingPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/Waterways/RelentlessSwarmPower.cs
+++ b/LoreMaster/LorePowers/Waterways/RelentlessSwarmPower.cs
@@ -7,7 +7,7 @@ public class RelentlessSwarmPower : Power
 {
     #region Constructors
 
-    public RelentlessSwarmPower() : base("Relentless Swarm", Area.WaterWays) { }
+    public RelentlessSwarmPower() : base("Relentless Swarm", Area.Waterways) { }
 
     #endregion
 
@@ -24,7 +24,7 @@ public class RelentlessSwarmPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => On.SpellFluke.DoDamage += SpellFluke_DoDamage;

--- a/LoreMaster/LorePowers/WhitePalace/DiminishingCursePower.cs
+++ b/LoreMaster/LorePowers/WhitePalace/DiminishingCursePower.cs
@@ -41,7 +41,7 @@ public class DiminishingCursePower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable()

--- a/LoreMaster/LorePowers/WhitePalace/SacredShellPower.cs
+++ b/LoreMaster/LorePowers/WhitePalace/SacredShellPower.cs
@@ -17,7 +17,7 @@ public class SacredShellPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => ModHooks.AfterTakeDamageHook += ModHooks_AfterTakeDamageHook;

--- a/LoreMaster/LorePowers/WhitePalace/ShadowForgedPower.cs
+++ b/LoreMaster/LorePowers/WhitePalace/ShadowForgedPower.cs
@@ -37,7 +37,7 @@ public class ShadowForgedPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Initialize()

--- a/LoreMaster/LorePowers/WhitePalace/ShiningBoundPower.cs
+++ b/LoreMaster/LorePowers/WhitePalace/ShiningBoundPower.cs
@@ -15,7 +15,7 @@ public class ShiningBoundPower : Power
 
     #endregion
 
-    #region Protected Methods
+    #region Control
 
     /// <inheritdoc/>
     protected override void Enable() => _runningCoroutine = LoreMaster.Instance.Handler.StartCoroutine(GatherShiningSoul());
@@ -25,21 +25,16 @@ public class ShiningBoundPower : Power
     #region Private Methods
 
     /// <summary>
-    /// Gather soul.
+    /// Gather soul over time.
     /// </summary>
-    /// <returns></returns>
     private IEnumerator GatherShiningSoul()
     {
         while (true)
         {
             yield return new WaitForSeconds(2f);
             if (PlayerData.instance.equippedCharms.Count > 0)
-            {
                 HeroController.instance.AddMPCharge(PlayerData.instance.equippedCharms.Count);
-            }
-
         }
-
     }
 
     #endregion

--- a/LoreMaster/Manager/SettingManager.cs
+++ b/LoreMaster/Manager/SettingManager.cs
@@ -11,11 +11,9 @@ using LoreMaster.Enums;
 using LoreMaster.Extensions;
 using LoreMaster.Helper;
 using LoreMaster.LorePowers;
-using LoreMaster.LorePowers.CityOfTears;
 using LoreMaster.LorePowers.FungalWastes;
 using LoreMaster.LorePowers.QueensGarden;
 using LoreMaster.LorePowers.WhitePalace;
-using LoreMaster.Properties;
 using LoreMaster.Randomizer;
 using LoreMaster.UnityComponents;
 using Modding;
@@ -46,7 +44,7 @@ internal class SettingManager
         {Area.FogCanyon, new(){MapZone.FOG_CANYON, MapZone.OVERGROWN_MOUND, MapZone.MONOMON_ARCHIVE} },
         {Area.KingdomsEdge, new(){MapZone.COLOSSEUM, MapZone.OUTSKIRTS, MapZone.HIVE, MapZone.TRAM_LOWER, MapZone.WYRMSKIN} },
         {Area.Deepnest, new(){MapZone.DEEPNEST, MapZone.TRAM_LOWER, MapZone.BEASTS_DEN, MapZone.RUINED_TRAMWAY} },
-        {Area.WaterWays, new(){MapZone.WATERWAYS, MapZone.GODS_GLORY, MapZone.GODSEEKER_WASTE, MapZone.ISMAS_GROVE} },
+        {Area.Waterways, new(){MapZone.WATERWAYS, MapZone.GODS_GLORY, MapZone.GODSEEKER_WASTE, MapZone.ISMAS_GROVE} },
         {Area.Cliffs, new(){MapZone.CLIFFS, MapZone.JONI_GRAVE } },
         {Area.AncientBasin, new(){MapZone.BONE_FOREST, MapZone.PALACE_GROUNDS, MapZone.TRAM_LOWER, MapZone.ABYSS, MapZone.ABYSS_DEEP} },
         {Area.CityOfTears, new(){MapZone.CITY, MapZone.SOUL_SOCIETY, MapZone.LURIENS_TOWER, MapZone.LOVE_TOWER, MapZone.MAGE_TOWER } },
@@ -103,18 +101,28 @@ internal class SettingManager
     {
         try
         {
+            // Add items for the black egg temple teleporter.
             ItemChangerMod.CreateSettingsProfile(false);
-            ItemManager.ResetItems();
+            List<MutablePlacement> teleportItems = new();
+            MutablePlacement teleportPlacement = new CoordinateLocation() { x = 35.0f, y = 5.4f, elevation = 0, sceneName = "Ruins1_27", name = "City_Teleporter" }.Wrap() as MutablePlacement;
+            teleportPlacement.Cost = new Paypal { ToTemple = true };
+            teleportPlacement.Add(new TouristMagnetItem("City_Teleporter"));
+            teleportItems.Add(teleportPlacement);
+
+            MutablePlacement secondPlacement = new CoordinateLocation() { x = 57f, y = 5f, elevation = 0, sceneName = "Room_temple", name = "Temple_Teleporter" }.Wrap() as MutablePlacement;
+            secondPlacement.Cost = new Paypal { ToTemple = false };
+            secondPlacement.Add(new TouristMagnetItem("Temple_Teleporter"));
+            teleportItems.Add(secondPlacement);
+            ItemChangerMod.AddPlacements(teleportItems);
+
+
+            GloryOfTheWealthPower.GloryCost = 0;
             On.PlayMakerFSM.OnEnable += FsmEdits;
             orig(self, permaDeath, bossRush);
             ModHooks.SetPlayerBoolHook += TrackPathOfPain;
             _fromMenu = true;
+
             PowerManager.ResetPowers();
-#if DEBUG
-            //foreach (Power power in PowerManager.GetAllPowers())
-            //    if (!PowerManager.ActivePowers.Contains(power))
-            //        PowerManager.ActivePowers.Add(power);
-#endif
             ModHooks.LanguageGetHook += LoreManager.Instance.GetText;
             On.DeactivateIfPlayerdataTrue.OnEnable += ForceMyla;
             On.DeactivateIfPlayerdataFalse.OnEnable += PreventMylaZombie;
@@ -129,6 +137,7 @@ internal class SettingManager
                 LoreManager.Instance.CanRead = true;
                 LoreManager.Instance.CanListen = true;
             }
+
         }
         catch (Exception exception)
         {
@@ -240,9 +249,6 @@ internal class SettingManager
                 // Initialization
                 if (_fromMenu)
                 {
-#if DEBUG
-
-#endif
                     if (string.Equals(arg1.name.ToLower(), "town"))
                     {
                         Transform elderbug = GameObject.Find("_NPCs/Elderbug").transform;
@@ -265,8 +271,7 @@ internal class SettingManager
                     }
                     catch (Exception exception)
                     {
-                        LoreMaster.Instance.LogError("An error occured while modifying dreamer cutscene: " + exception.Message);
-                        LoreMaster.Instance.LogError("An error occured while modifying dreamer cutscene: " + exception.StackTrace);
+                        LoreMaster.Instance.LogError("An error occured while modifying IC: " + exception.Message);
                     }
 
                     // Load in changes from the options file (if it exists)
@@ -654,7 +659,6 @@ internal class SettingManager
             _fromMenu = false;
             PowerManager.FirstPowerInitialization();
             PowerManager.UpdateTracker(newArea);
-            TreasureHunterPower.UpdateTreasurePage();
         }
         LorePage.UpdateLorePage();
 

--- a/LoreMaster/Randomizer/RandomizerManager.cs
+++ b/LoreMaster/Randomizer/RandomizerManager.cs
@@ -15,6 +15,7 @@ using LoreMaster.LorePowers.CityOfTears;
 using LoreMaster.LorePowers.RestingGrounds;
 using LoreMaster.LorePowers;
 using ItemChanger.Tags;
+using Modding;
 
 namespace LoreMaster.Randomizer;
 
@@ -37,7 +38,7 @@ public static class RandomizerManager
         {Area.QueensGarden, "Queen's Gardens"},
         {Area.Peaks, "Crystal Peaks"},
         {Area.RestingGrounds, "Resting Grounds"},
-        {Area.WaterWays, "Royal Waterways"},
+        {Area.Waterways, "Royal Waterways"},
         {Area.KingdomsEdge, "Kingdom's Edge"},
         {Area.FogCanyon, "Fog Canyon"},
         {Area.Cliffs, "Howling Cliffs"},
@@ -401,7 +402,7 @@ public static class RandomizerManager
                     if (PowerManager.GetPowerByKey("EMILITIA", out power, false) && PowerManager.ActivePowers.Contains(power))
                         collectedPowerAmount++;
                     break;
-                case Area.WaterWays:
+                case Area.Waterways:
                     maxPowerAmount++;
                     if (PowerManager.GetPowerByKey("FLUKE_HERMIT", out power, false) && PowerManager.ActivePowers.Contains(power))
                         collectedPowerAmount++;


### PR DESCRIPTION
- Simplified Fsm, GameObject and State call in On.Action hooks.
- Created method for terminating hooks upon exiting the game.
- Added OnHeroControllerStart hooks for hero specific modification to prevent hero reset errors. (When Benchwarp creates a new HeroController instance for example)
- Renamed power handling region to control (Enable, Disable etc)